### PR TITLE
Add additional imbue attempt with JSON decoder.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/BakedSoftware/go-parameters
+
+go 1.14
+
+require (
+	github.com/gorilla/mux v1.8.0
+	github.com/julienschmidt/httprouter v1.3.0
+	github.com/ugorji/go/codec v1.2.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/ugorji/go v1.2.5 h1:NozRHfUeEta89taVkyfsDVSy2f7v89Frft4pjnWuGuc=
+github.com/ugorji/go v1.2.5/go.mod h1:gat2tIT8KJG8TVI8yv77nEO/KYT6dV7JE1gfUa8Xuls=
+github.com/ugorji/go/codec v1.2.5 h1:8WobZKAk18Msm2CothY2jnztY56YVY8kF1oQrj21iis=
+github.com/ugorji/go/codec v1.2.5/go.mod h1:QPxoTbPKSEAlAHPYt02++xp/en9B/wUdwFCz+hj5caA=


### PR DESCRIPTION
## Problem

Nested structs require custom `Imbue` even if that struct has a trivial implementation.

## Changes

- Make `Imbue` handle nested structs using recursion.

We will still try the `CustomTypeSetter` first and if that fails, then proceed to recursion.

## Breaking Changes

The `CustomTypeHandler` type now needs to return an `error`